### PR TITLE
use defineProperty instead of defineGetter which is more widely available

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,11 @@ function Queue(options) {
 }
 util.inherits(Queue, EventEmitter);
 
-Queue.prototype.__defineGetter__('length', function() {
+Object.defineProperty(Queue.prototype, 'length', { get: length });
+
+function length() {
   return this.pending + this.jobs.length;
-});
+}
 
 // expose selected array methods
 [ 'pop', 'shift', 'slice', 'reverse', 'indexOf', 'lastIndexOf' ].forEach(function(method) {


### PR DESCRIPTION
defineGetter is non standard: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineGetter

defineProperty also makes queue available to IEx, see how https://github.com/vvo/chainit uses queue and test on browsers

Thank you again for queue.
