### PR TITLE
Added fix for resuming queue with pending workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 node_modules
 test/bundle.js
 coverage

--- a/index.js
+++ b/index.js
@@ -111,6 +111,11 @@ Queue.prototype.stop = function() {
   this.running = false;
 };
 
+Queue.prototype.resume = function() {
+  this.running = true;
+  this.start();
+};
+
 Queue.prototype.end = function(err) {
   this.jobs.length = 0;
   this.pending = 0;

--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ Queue.prototype.start = function(cb) {
     callOnErrorOrEnd.call(this, cb);
   }
 
+  this.running = true;
+
   if (this.pending === this.concurrency) {
     return;
   }
@@ -99,7 +101,6 @@ Queue.prototype.start = function(cb) {
   }
   
   this.pending++;
-  this.running = true;
   job(next);
   
   if (this.jobs.length > 0) {
@@ -109,11 +110,6 @@ Queue.prototype.start = function(cb) {
 
 Queue.prototype.stop = function() {
   this.running = false;
-};
-
-Queue.prototype.resume = function() {
-  this.running = true;
-  this.start();
 };
 
 Queue.prototype.end = function(err) {

--- a/test/index.js
+++ b/test/index.js
@@ -7,3 +7,4 @@ require('./stop');
 require('./end');
 require('./error-sync');
 require('./error-async');
+require('./resume');

--- a/test/resume.js
+++ b/test/resume.js
@@ -2,27 +2,27 @@ var tape = require('tape');
 var queue = require('../');
 
 tape('resume', function(t) {
-    t.plan(16);
+  t.plan(16);
 
-    var q = queue({ concurrency: 2 });
+  var q = queue({ concurrency: 2 });
 
-    var jobsToSet = 16;
+  var jobsToSet = 16;
 
-    while (jobsToSet--) {
-        q.push(function(cb) {
-            setTimeout(function() {
-                t.ok(q);
-                cb();
-            }, 200);
-        });
-    }
+  while (jobsToSet--) {
+    q.push(function(cb) {
+      setTimeout(function() {
+        t.ok(q);
+        cb();
+      }, 200);
+    });
+  }
 
-    // start
+  // start
+  q.start();
+
+  // and stop somewhere in the middle of queue
+  setTimeout(function() {
+      q.stop();
     q.start();
-
-    // and stop somewhere in the middle of queue
-    setTimeout(function() {
-        q.stop();
-        q.resume();
-    }, 600);
+  }, 600);
 });

--- a/test/resume.js
+++ b/test/resume.js
@@ -1,0 +1,28 @@
+var tape = require('tape');
+var queue = require('../');
+
+tape('resume', function(t) {
+    t.plan(16);
+
+    var q = queue({ concurrency: 2 });
+
+    var jobsToSet = 16;
+
+    while (jobsToSet--) {
+        q.push(function(cb) {
+            setTimeout(function() {
+                t.ok(q);
+                cb();
+            }, 200);
+        });
+    }
+
+    // start
+    q.start();
+
+    // and stop somewhere in the middle of queue
+    setTimeout(function() {
+        q.stop();
+        q.resume();
+    }, 600);
+});


### PR DESCRIPTION
Currently when you create queue with concurency value more then 1, stop it and try to run again calling 'start' method queue doesn't resume. It happens only when pending value is more then one and running is set to false. So I created new method 'resume' that is solve that problem. Actually it's call 'start' method, but set running to true before.

To reproduce this bug you can call start method instead of resume in tests that I added.