### PR TITLE
Fix for "cannot update concurrency mid-process" (#37)

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ Queue.prototype.start = function (cb) {
 
   this.running = true
 
-  if (this.pending === this.concurrency) {
+  if (this.pending >= this.concurrency) {
     return
   }
 

--- a/test/concurrent.js
+++ b/test/concurrent.js
@@ -2,10 +2,18 @@ var tape = require('tape')
 var queue = require('../')
 
 tape('concurrent', function (t) {
-  t.plan(4)
+  t.plan(6)
 
   var actual = []
   var q = queue()
+  q.concurrency = 2
+
+  q.push(function (cb) {
+    setTimeout(function () {
+      actual.push('two')
+      cb()
+    }, 20)
+  })
 
   q.push(function (cb) {
     setTimeout(function () {
@@ -15,21 +23,29 @@ tape('concurrent', function (t) {
   })
 
   q.push(function (cb) {
+    q.concurrency = 1
     setTimeout(function () {
       actual.push('three')
       cb()
-    }, 20)
+    }, 30)
   })
 
   q.push(function (cb) {
     setTimeout(function () {
-      actual.push('two')
+      actual.push('four')
       cb()
     }, 10)
   })
 
+  q.push(function (cb) {
+    setTimeout(function () {
+      actual.push('five')
+      cb()
+    }, 0)
+  })
+
   q.start(function () {
-    var expected = [ 'one', 'two', 'three' ]
+    var expected = [ 'one', 'two', 'three', 'four', 'five' ]
     t.equal(actual.length, expected.length)
 
     for (var i in actual) {


### PR DESCRIPTION
Refer to #37 for more info.

With this change, concurrency can be changed mid-process and the behavior is as expected:

```
start job 1
finish, q length = 19
start job 2
finish, q length = 18
start job 3
finish, q length = 17
start job 4
start job 5
start job 6
start job 7
finish, q length = 16
start job 8
finish, q length = 15
start job 9
finish, q length = 14
start job 10
finish, q length = 13
start job 11
finish, q length = 12
start job 12
finish, q length = 11
start job 13
finish, q length = 10
start job 14
finish, q length = 9
start job 15
finish, q length = 8
start job 16
finish, q length = 7
start job 17
finish, q length = 22
finish, q length = 21
finish, q length = 20
finish, q length = 19
start job 18
finish, q length = 18
start job 19
finish, q length = 17
start job 20
finish, q length = 16
start job 21
finish, q length = 15
start job 22
finish, q length = 14
start job 23
finish, q length = 13
start job 24
finish, q length = 12
start job 25
finish, q length = 11
start job 26
finish, q length = 10
start job 27
finish, q length = 9
start job 28
finish, q length = 8
start job 29
finish, q length = 7
start job 30
finish, q length = 6
start job 31
finish, q length = 5
start job 32
finish, q length = 4
start job 33
finish, q length = 3
start job 34
finish, q length = 2
start job 35
finish, q length = 1
yay
```