### PR TITLE
Improve concurrency tests further

### DIFF
--- a/test/concurrent.js
+++ b/test/concurrent.js
@@ -2,7 +2,7 @@ var tape = require('tape')
 var queue = require('../')
 
 tape('concurrent', function (t) {
-  t.plan(6)
+  t.plan(7)
 
   var actual = []
   var q = queue()
@@ -10,7 +10,7 @@ tape('concurrent', function (t) {
 
   q.push(function (cb) {
     setTimeout(function () {
-      actual.push('two')
+      actual.push('four')
       cb()
     }, 20)
   })
@@ -23,16 +23,16 @@ tape('concurrent', function (t) {
   })
 
   q.push(function (cb) {
-    q.concurrency = 1
     setTimeout(function () {
-      actual.push('three')
+      actual.push('two')
       cb()
-    }, 30)
+    }, 0)
   })
 
   q.push(function (cb) {
+    q.concurrency = 1
     setTimeout(function () {
-      actual.push('four')
+      actual.push('three')
       cb()
     }, 10)
   })
@@ -41,11 +41,18 @@ tape('concurrent', function (t) {
     setTimeout(function () {
       actual.push('five')
       cb()
+    }, 30)
+  })
+
+  q.push(function (cb) {
+    setTimeout(function () {
+      actual.push('six')
+      cb()
     }, 0)
   })
 
   q.start(function () {
-    var expected = [ 'one', 'two', 'three', 'four', 'five' ]
+    var expected = [ 'one', 'two', 'three', 'four', 'five', 'six' ]
     t.equal(actual.length, expected.length)
 
     for (var i in actual) {

--- a/test/concurrent.js
+++ b/test/concurrent.js
@@ -2,18 +2,10 @@ var tape = require('tape')
 var queue = require('../')
 
 tape('concurrent', function (t) {
-  t.plan(7)
+  t.plan(4)
 
   var actual = []
   var q = queue()
-  q.concurrency = 2
-
-  q.push(function (cb) {
-    setTimeout(function () {
-      actual.push('four')
-      cb()
-    }, 20)
-  })
 
   q.push(function (cb) {
     setTimeout(function () {
@@ -24,35 +16,96 @@ tape('concurrent', function (t) {
 
   q.push(function (cb) {
     setTimeout(function () {
+      actual.push('three')
+      cb()
+    }, 20)
+  })
+
+  q.push(function (cb) {
+    setTimeout(function () {
       actual.push('two')
+      cb()
+    }, 10)
+  })
+
+  q.start(function () {
+    var expected = [ 'one', 'two', 'three' ]
+    t.equal(actual.length, expected.length)
+
+    for (var i in actual) {
+      var a = actual[i]
+      var e = expected[i]
+      t.equal(a, e)
+    }
+  })
+})
+
+tape('concurrent with changes', function (t) {
+  t.plan(13)
+
+  var actual = []
+  var q = queue()
+  q.concurrency = 2
+
+  q.push(function (cb) {
+    actual.push('one.start')
+    setTimeout(function () {
+      actual.push('one.end')
+      cb()
+    }, 20)
+  })
+
+  q.push(function (cb) {
+    actual.push('two.start')
+    setTimeout(function () {
+      actual.push('two.end')
       cb()
     }, 0)
   })
 
   q.push(function (cb) {
+    actual.push('three.start')
+    setTimeout(function () {
+      actual.push('three.end')
+      cb()
+    }, 0)
+  })
+
+  q.push(function (cb) {
+    actual.push('four.start')
     q.concurrency = 1
     setTimeout(function () {
-      actual.push('three')
+      actual.push('four.end')
       cb()
     }, 10)
   })
 
   q.push(function (cb) {
+    actual.push('five.start')
     setTimeout(function () {
-      actual.push('five')
+      actual.push('five.end')
       cb()
     }, 30)
   })
 
   q.push(function (cb) {
+    actual.push('six.start')
     setTimeout(function () {
-      actual.push('six')
+      actual.push('six.end')
       cb()
     }, 0)
   })
 
   q.start(function () {
-    var expected = [ 'one', 'two', 'three', 'four', 'five', 'six' ]
+    var expected = [
+      'one.start',
+      'two.start', 'two.end',
+      'three.start', 'three.end',
+      'four.start', 'four.end', // <-- concurrency dropped
+      'one.end',
+      'five.start', 'five.end',
+      'six.start', 'six.end'
+    ]
     t.equal(actual.length, expected.length)
 
     for (var i in actual) {


### PR DESCRIPTION
I improved the concurrency tests a bit. 

This way you can check that concurrency is applied to more than 2 jobs (4 in total), before its reduced down to 1.

Still passes, but this way it covers an extra scenario where you want to maintain concurrency while consuming extra jobs.