### PR TITLE
Add readme suggestion for `events` library dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,9 @@ q.start(function (err) {
 ## Install
 `npm install queue`
 
+_Note_: You may need to install the [`events`](https://github.com/Gozala/events) dependency if 
+your environment does not have it by default (eg. browser, react-native). 
+
 ## Test
 `npm test`
 `npm run test-browser`


### PR DESCRIPTION
As this library implicitly requires the `events` dependency, I added a note in the README.md as a suggestion for users of this library to install the [`events`](https://github.com/Gozala/events) library if they are using this library in an environment that doesn't have it by default (eg. browser, react-native).