### PR TITLE
Emit a start event when a job begins to process

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,8 +140,8 @@ Queue.prototype.start = function (cb) {
   }
 
   this.pending++
-  var promise = job(next)
   self.emit('start', job)
+  var promise = job(next)
   if (promise && promise.then && typeof promise.then === 'function') {
     promise.then(function (result) {
       return next(null, result)

--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ Queue.prototype.start = function (cb) {
 
   this.pending++
   var promise = job(next)
+  self.emit('start', job)
   if (promise && promise.then && typeof promise.then === 'function') {
     promise.then(function (result) {
       return next(null, result)

--- a/test/start.js
+++ b/test/start.js
@@ -2,7 +2,7 @@ var tape = require('tape')
 var queue = require('../')
 
 tape('start', function (t) {
-  t.plan(3)
+  t.plan(4)
 
   var q = queue()
 
@@ -18,4 +18,15 @@ tape('start', function (t) {
       t.ok(q)
     })
   })
+
+  q.on('start', function (job) {
+    t.equals(job, work)
+  })
+
+  function work (cb) {
+    cb()
+  }
+
+  q.push(work)
+  q.start()
 })

--- a/test/start.js
+++ b/test/start.js
@@ -5,11 +5,16 @@ tape('start', function (t) {
   t.plan(4)
 
   var q = queue()
-
-  q.push(function (cb) {
+  function work (cb) {
     t.ok(q)
     cb()
+  }
+
+  q.on('start', function (job) {
+    t.equals(job, work)
   })
+
+  q.push(work)
 
   q.start(function () {
     t.ok(q)
@@ -18,15 +23,4 @@ tape('start', function (t) {
       t.ok(q)
     })
   })
-
-  q.on('start', function (job) {
-    t.equals(job, work)
-  })
-
-  function work (cb) {
-    cb()
-  }
-
-  q.push(work)
-  q.start()
 })


### PR DESCRIPTION
Really appreciate this module and all the work that has gone into it. It's a great example of a simple library that does one thing really well, and is readable. Thanks so much!

This adds a simple `start` event when a job begins (and exposes that job fn to any listeners). This is useful, in my case, where we append properties to the `job` so that we can track things like duration in the queue, when it started etc. Adds a test case as well.