### PR TITLE
Ensuring jobs can opt-out of the "global" timeout

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -69,6 +69,17 @@ function extraSlowJob (cb) {
 extraSlowJob.timeout = 500
 q.push(extraSlowJob)
 
+// jobs can also opt-out of the timeout altogether
+function superSlowJob (cb) {
+  setTimeout(function () {
+    console.log('super slow job finished')
+    cb()
+  }, 1000)
+}
+
+superSlowJob.timeout = null
+q.push(superSlowJob)
+
 // get notified when jobs complete
 q.on('success', function (result, job) {
   console.log('job finished processing:', job.toString().replace(/\n/g, ''))

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ Queue.prototype.start = function (cb) {
   var timeoutId = null
   var didTimeout = false
   var resultIndex = null
-  var timeout = job.timeout || this.timeout
+  var timeout = job.hasOwnProperty('timeout') ? job.timeout : this.timeout
 
   function next (err, result) {
     if (once && self.session === session) {

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,17 @@ function extraSlowJob (cb) {
 extraSlowJob.timeout = 500
 q.push(extraSlowJob)
 
+// jobs can also opt-out of the timeout altogether
+function superSlowJob (cb) {
+  setTimeout(function () {
+    console.log('super slow job finished')
+    cb()
+  }, 10000)
+}
+
+superSlowJob.timeout = undefined
+q.push(superSlowJob)
+
 // get notified when jobs complete
 q.on('success', function (result, job) {
   console.log('job finished processing:', job.toString().replace(/\n/g, ''))
@@ -104,8 +115,8 @@ q.start(function (err) {
 ## Install
 `npm install queue`
 
-_Note_: You may need to install the [`events`](https://github.com/Gozala/events) dependency if 
-your environment does not have it by default (eg. browser, react-native). 
+_Note_: You may need to install the [`events`](https://github.com/Gozala/events) dependency if
+your environment does not have it by default (eg. browser, react-native).
 
 ## Test
 `npm test`

--- a/readme.md
+++ b/readme.md
@@ -92,10 +92,10 @@ function superSlowJob (cb) {
   setTimeout(function () {
     console.log('super slow job finished')
     cb()
-  }, 10000)
+  }, 1000)
 }
 
-superSlowJob.timeout = undefined
+superSlowJob.timeout = null
 q.push(superSlowJob)
 
 // get notified when jobs complete
@@ -115,8 +115,8 @@ q.start(function (err) {
 ## Install
 `npm install queue`
 
-_Note_: You may need to install the [`events`](https://github.com/Gozala/events) dependency if
-your environment does not have it by default (eg. browser, react-native).
+_Note_: You may need to install the [`events`](https://github.com/Gozala/events) dependency if 
+your environment does not have it by default (eg. browser, react-native). 
 
 ## Test
 `npm test`

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -79,7 +79,7 @@ tape('job-based opt-out of timeout', function (t) {
     setTimeout(cb, 8)
   }
 
-  wontTimeout.timeout = undefined
+  wontTimeout.timeout = null
 
   q.on('timeout', function (next) {
     t.fail('Job should not have timed-out')

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -70,6 +70,32 @@ tape('job timeout', function (t) {
   q.start()
 })
 
+tape('job-based opt-out of timeout', function (t) {
+  t.plan(1)
+
+  var timeouts = 0
+  var q = queue({ timeout: 5 })
+  function wontTimeout (cb) {
+    setTimeout(cb, 8)
+  }
+
+  wontTimeout.timeout = undefined
+
+  q.on('timeout', function (next) {
+    t.fail('Job should not have timed-out')
+    timeouts++
+    next()
+  })
+
+  q.on('end', function () {
+    t.equal(timeouts, 0)
+  })
+
+  q.push(wontTimeout)
+
+  q.start()
+})
+
 tape('timeout auto-continue', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
I've run into cases where opting-out of the "global" timer is necessary, and there's no way to do that given the current implementation. This addresses that by checking for the `timeout` property on a job and seeing if it's set vs doing a coercion check on that property.

I'm on the fence about the interface, however. Setting this to `undefined` feels odd, and forces some complexity down into consumers (having to set it explicitly, harder to do easier coercion checks). I've done `job.timeout = false`, but that makes the implementation here more complex.

In any case I've gone ahead with the `undefined` and added a test + document for it to clear it up even though it's odd.