### PR TITLE
Added ability to reset the timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,14 +124,21 @@ Queue.prototype.start = function (cb) {
   }
 
   if (timeout) {
-    timeoutId = setTimeout(function () {
-      didTimeout = true
-      if (self.listeners('timeout').length > 0) {
-        self.emit('timeout', next, job)
-      } else {
-        next()
-      }
-    }, timeout)
+    function resetTimeout() {
+      delete self.timers[timeoutId]
+      clearTimeout(timeoutId)
+
+      return setTimeout(function () {
+        didTimeout = true
+        if (self.listeners('timeout').length > 0) {
+          self.emit('timeout', next, job, resetTimeout)
+        } else {
+          next()
+        }
+      }, timeout)
+    }
+
+    timeoutId = resetTimeout()
     this.timers[timeoutId] = timeoutId
   }
 


### PR DESCRIPTION
Example use:

```
  q.on('timeout', (next, job, resetTimeout) => {
    if (job.stillAlive) {
      console.log('Job said it was still working on something, giving it more time to finish')
      job.stillAlive = false
      resetTimeout()
      return
    }

    processJobError(job, 'Job timed out')
    next()
  })
```