### PR TITLE
fix(typings): QueueWorkerCallback cannot be undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -160,7 +160,7 @@ declare const Queue: QueueConstructor;
 export default Queue;
 
 export interface QueueWorker {
-    (callback?: QueueWorkerCallback): void;
+    (callback: QueueWorkerCallback): void;
 
     /**
      * Override queue timeout.


### PR DESCRIPTION
With TypeScript's `strict` mode enabled, I get errors telling me that the `next()` function can be undefined as, which is not the case when I checked the code. This pr aims to fix that issue.