### PR TITLE
fix(typings): define QueueConstructor.prototype

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -153,6 +153,7 @@ interface Queue extends EventEmitter {
 interface QueueConstructor {
     (options?: Options): Queue;
     new (options?: Options): Queue;
+    prototype: Queue;
 }
 
 declare const Queue: QueueConstructor;


### PR DESCRIPTION
Seems like an oversight, hopefully this helps.