### PR TITLE
remove module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   ],
   "typings": "index.d.ts",
   "main": "index.js",
-  "module": "index.js",
   "type": "module",
   "devDependencies": {
     "c8": "^7.12.0",


### PR DESCRIPTION
didn't see a "module" field in the npm docs: https://docs.npmjs.com/cli/v9/configuring-npm/package-json any reason to keep it?